### PR TITLE
Added support for CNAME file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ The Docker container which powers the action runs Node which means `npm` command
 
 With the action correctly configured you should see the workflow trigger the deployment under the configured conditions.
 
+
+`PAGES_CNAME`: The CNAME to use for pages (Optional)
+
+This variable should contain the CNAME you want to run your pages under. The action will use this to generate the necessary `CNAME` file.
+
 ## Contributing
 
 We are a community effort, and everybody is most welcome to participate!

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,11 @@ if [ -z "$(git status --porcelain)" ]; then
     echo "Nothing to commit" && \
     exit 0
 fi && \
+if [[ "${PAGES_CNAME}" ]]
+then
+    echo "CNAME was set, writing CNAME file"
+    echo "${PAGES_CNAME}" > CNAME
+fi
 git add . && \
 git commit -m 'Deploy to GitHub Pages' && \
 git push --force $REMOTE_REPO master:$REMOTE_BRANCH && \


### PR DESCRIPTION
**Description**
These changes update the entrypoint script to support an environment variable which is used to generate a CNAME file.  This will automate pages deployment to custom domains.  The change also updates the README to reflect the changes.

**Testing Instructions**
Execute the action with an additional environment variable named `PAGES_CNAME`.  The resulting commit should contain the CNAME file.  

**Additional Notes**
None

-----
[View rendered README.md](https://github.com/rreichel3/github-pages-deploy-action/blob/add-support-for-cname/README.md)